### PR TITLE
Create {project_name} string token for buildDir string

### DIFF
--- a/lib/build-meson.js
+++ b/lib/build-meson.js
@@ -24,6 +24,9 @@ export function provideBuilder() {
             let buildDir = null;
             if (atom.config.get('build-meson.buildDir')) {
                 buildDir = atom.config.get('build-meson.buildDir');
+                if(buildDir.includes("{project_name}")) {
+                    buildDir=buildDir.replace("{project_name}",this.cwd.substring(this.cwd.lastIndexOf('/') + 1))
+                }
             } else {
                 buildDir = '_build';
             }

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,7 +5,7 @@ export default {
         type: 'string',
         default: '_build',
         title: 'Build directory name',
-        description: 'Set how will be called output build directory'
+        description: 'Set how will be called output build directory.\n'+'Option: Use {project_name} to create builds in with the project\'s name.'
     },
     installPrefix: {
         type: 'string',


### PR DESCRIPTION
Hello,
I added a little bit of code to provide for the option of creating a build path is a disposable directory.
Please consider merging at your earliest convenience.
Example:
/tmp/{project_name}/
Example:
/tmp/{project_name}/_build
